### PR TITLE
Support for AWS Arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM swift:5.7-amazonlinux2
 
-RUN echo "PLATFORM = $PLATFORM or ${PLATFORM} "
+RUN echo "PLATFORM = ${{ inputs.architecture }}"
 RUN yum -y install zip
 
 COPY build-package.sh /build-package.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM swift:5.7-amazonlinux2
 
-ARG INPUT_ARCHITECTURE
-RUN echo "INPUT_ARCHITECTURE = $INPUT_ARCHITECTURE"
+ARG PLATFORM
+RUN echo "PLATFORM = $PLATFORM"
 RUN yum -y install zip
 
 COPY build-package.sh /build-package.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.7-amazonlinux2
+FROM --platform=$PLATFORM swift:5.7-amazonlinux2
 
 RUN yum -y install zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM swift:5.7-amazonlinux2
 
-RUN echo "PLATFORM = ${{ inputs.architecture }}"
+ARG INPUT_ARCHITECTURE
+RUN echo "INPUT_ARCHITECTURE = $INPUT_ARCHITECTURE"
 RUN yum -y install zip
 
 COPY build-package.sh /build-package.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG PLATFORM
 FROM --platform=$PLATFORM swift:5.7-amazonlinux2
 
 RUN yum -y install zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG PLATFORM
-FROM --platform=$PLATFORM swift:5.7-amazonlinux2
+FROM swift:5.7-amazonlinux2
 
+RUN echo "PLATFORM = $PLATFORM or ${PLATFORM} "
 RUN yum -y install zip
 
 COPY build-package.sh /build-package.sh

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.executable }}
+    - '--build-arg PLATFORM=${{ inputs.architecture }}'
 branding:
   icon: 'code'
   color: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,17 @@ inputs:
   executable:
     description: 'Name of executable'
     required: true
+  architecture:
+    description: 'The platform this Lambda should be built for. (x86_64 or arm64).'
+    required: false
+    default: 'x86_64'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.executable }}
+  env: 
+    PLATFORM: ${{ inputs.architecture }}
 branding:
   icon: 'code'
   color: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,6 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.executable }}
-  env: 
-    PLATFORM: ${{ inputs.architecture }}
 branding:
   icon: 'code'
   color: 'orange'


### PR DESCRIPTION
Adds support for builting with docker image platform for `x86_64` or `arm64` as supported by AWS Lambdas.
